### PR TITLE
Correcting erroneous markdown syntax

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Code of Conduct
-=================
+-----------------
 Be kind to others. Do not insult or put down others. Behave professionally. All
 communication should be appropriate for a professional audience including
 people of many different backgrounds.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,19 @@
 # Contributing to shellplot
-===========================
+---------------------------
 Thank you for your interest in improving ```shellplot```! Below we describe our
 development process and how you can be part of it.
 
 ## Hosted on GitHub
-===================
+-------------------
 All development takes place on [GitHub](https://github.com).
 
 ## Code of Conduct
-==================
+------------------
 When you decide to contribute to this project, it is important to adhere to our
 **Code of Conduct**. For more information look in the [CODE OF CONDUCT] file.
 
 ## Bug reports and feature requests
-===================================
+-----------------------------------
 Bug reports and featuer requests are always welcome. To file a new issue,
 [head to the issue tracker](https://github.com/HyperEntangledQubit/shellplot/issues/new)
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # shellplot
-===========
+-----------
 **shellplot** is an os-agnostic python utility that allows for generation of
 plots in the terminal of your choice using popular visualization libraries
 matplotlib and ggplot2 (via plotnine).
 
 ## Usage
-==========
+--------
 
 ## Installation
-===============
+---------------
 
 ## Contributing
-===============
+---------------
 Contributions are welcome! For more information look at the [CONTRIBUTING] file.
 
 ## License
-==========
+----------
 Everything contributed in this repository is released under the ***Apache 2.0
 License***, for more information look at the [LICENSE] file.
 
-## See Also
-===========
+## See also
+-----------
 This project was heavily inspired by [bashplotlib](https://glamp/bashplotlib/blob/master/README.md)
 
 


### PR DESCRIPTION
Summary
-------
Updated all of the markdown files in the repo removing ```===``` and replace with ```---```.

Fixes #2