### PR TITLE
16 pull module info from pyprojecttoml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+name: shellplot
+channels:
+  - defaults
+dependencies:
+  - bzip2=1.0.8=h620ffc9_4
+  - ca-certificates=2023.12.12=hca03da5_0
+  - libffi=3.4.4=hca03da5_0
+  - ncurses=6.4=h313beb8_0
+  - openssl=3.0.12=h1a28f6b_0
+  - pip=23.3.1=py311hca03da5_0
+  - python=3.11.7=hb885b13_0
+  - readline=8.2=h1a28f6b_0
+  - setuptools=68.2.2=py311hca03da5_0
+  - sqlite=3.41.2=h80987f9_0
+  - tk=8.6.12=hb8d0fd4_0
+  - tzdata=2023d=h04d1e81_0
+  - wheel=0.41.2=py311hca03da5_0
+  - xz=5.4.5=h80987f9_0
+  - zlib=1.2.13=h5a0b063_0
+  - pip:
+      - toml==0.10.2
+

--- a/src/__about__.py
+++ b/src/__about__.py
@@ -1,7 +1,13 @@
 # Fill in SPDR info here
-# Using pull version info from pyproject.toml and set using semver lib here
+import os
+import toml
+from pathlib import Path
 
-# Pull the version number from pyporject.toml when added
-__version__ = None
+# Pull module info from pyproject.toml
+pyproject_path = Path(os.pardir, "pyproject.toml").resolve()
+pyproject = toml.load(pyproject_path)['project']
 
-__author__ = "HyperEntangledQubit and individual contributors"
+__name__ = pyproject['name']
+__version__ = pyproject['version']
+__author__ = pyproject['authors']
+__description__ = pyproject['description']


### PR DESCRIPTION
Pulling module info from pyproject.toml.

Summary
-------
Pulling the module info form pyproject.toml and placing it into
__about__.py. Also adding an environment.yaml file to the repo.

Fixes #16
