### PR TITLE
18 update pyprojecttoml deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=61.0.0",
+]
+
 
 [project]
 name = "shellplot"
@@ -35,4 +40,6 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Visualization",
 ]
 requires-python = ">=3.7"
-dependencies = []
+dependencies = [
+  "toml",
+]


### PR DESCRIPTION
Adding toml dependency and specifying setuptools into ```pyproject.toml```

    Summary
    -------
    Previously added ```toml``` lib to parse values in ```pyproject.toml```.
    Did not add ```toml``` dependency into pyproject.toml as specified by Python
    Packaging user guide.

    Fixes #18