### PR TITLE
22 add spdx license identifier into source files

### DIFF
--- a/src/__about__.py
+++ b/src/__about__.py
@@ -1,4 +1,5 @@
-# Fill in SPDR info here
+# SPDX-License-Identifier: Apache-2.0
+"""Shellplot package information."""
 import os
 import toml
 from pathlib import Path

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,5 @@
-# Include SPDR info here
-
+# SPDX-License-Identifier: Apache-2.0
+"""Terminal agnostic plotting tool"""
 __all__  = [
         "__about__",
         "__version__",


### PR DESCRIPTION
Adding SPDX License identifier information.

Summary
--------
Adding SPDX License identifier information into source files. Also added
package level docstrings for __about__.py and __init__.py.

Fixes #22  